### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/argonauths/3b0587c4-b3e1-46bd-8c51-885752deec01/43e50f28-2bb5-4de8-8a2b-4efb60efde6a/_apis/work/boardbadge/b832661c-dd6a-450e-8275-363e489b8484)](https://dev.azure.com/argonauths/3b0587c4-b3e1-46bd-8c51-885752deec01/_boards/board/t/43e50f28-2bb5-4de8-8a2b-4efb60efde6a/Microsoft.RequirementCategory)
 ## Purpose of this repository
 
 Demonstrate how OCA core components interact with each other.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#5](https://dev.azure.com/argonauths/3b0587c4-b3e1-46bd-8c51-885752deec01/_workitems/edit/5). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.